### PR TITLE
Return actual Class name rather than namespaced version in search results.

### DIFF
--- a/app/helpers/refinery/search_helper.rb
+++ b/app/helpers/refinery/search_helper.rb
@@ -6,7 +6,7 @@ module Refinery
     end
 
     def result_type(result)
-      result.class.to_s.titleize.gsub('Refinery/', '').gsub '/', '::'
+      result.class.to_s.titleize.split("/").last
     end
 
     # this is where you register your result URLs based on the


### PR DESCRIPTION
When searching models that are part of an extension, the extension name and model are returned in the results

Previous Behaviour:

``` ruby
'Refinery/Page' => 'Page'
'Refinery/Extension/Model' => 'Extension/Model'
```

New Behaviour:

``` ruby
'Refinery/Page' => 'Page'
'Refinery/Extension/Model' => 'Model'
```
