### PR TITLE
Allow a name to be defined to be display in search results.

### DIFF
--- a/app/helpers/refinery/search_helper.rb
+++ b/app/helpers/refinery/search_helper.rb
@@ -6,7 +6,11 @@ module Refinery
     end
 
     def result_type(result)
-      result.class.to_s.titleize.split("/").last
+      if result.class.method_defined?(:friendly_search_name)
+        result.friendly_search_name
+      else
+        result.class.to_s.titleize.split("/").last
+      end
     end
 
     # this is where you register your result URLs based on the

--- a/app/views/refinery/search/show.html.erb
+++ b/app/views/refinery/search/show.html.erb
@@ -10,11 +10,7 @@
       <% @results.each do |result| %>
         <li>
           <span class='result_type'>
-            <% if result.class.method_defined?(:friendly_search_name) %>
-              <%= result.friendly_search_name %>
-            <% else %>
-              <%= result_type result %>
-            <% end %>
+            <%= result_type result %>
           </span>
           <%= link_to result_title(result).html_safe, result_url(result) %>
         </li>


### PR DESCRIPTION
While the current implementation uses the class name in the search results. It would be good to be able to define our own custom names. This PR addresses that by allowing the user to define this in the model:

```
def friendly_search_name
  "Document"
end
```
