### PR TITLE
Add refinerycms-acts-as-indexed to gemspec (fix github issue #41).

### DIFF
--- a/refinerycms-search.gemspec
+++ b/refinerycms-search.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency    'refinerycms-core', '~> 2.1.0.dev'
+  s.add_dependency    'refinerycms-acts-as-indexed', '~> 1.0.0'
 end


### PR DESCRIPTION
I believe this fixes issue #41 and will allow the Travis CI build to pass.
