### PR TITLE
Try convert query params to_ascii

### DIFF
--- a/app/controllers/refinery/search/search_controller.rb
+++ b/app/controllers/refinery/search/search_controller.rb
@@ -7,7 +7,7 @@ module Refinery
       before_action :find_page
 
       def show
-        @results = Refinery::Search::SearchEngine.search(params[:query])
+        @results = Refinery::Search::SearchEngine.search(params[:query].try(:to_ascii))
         @results = @results.paginate(page: params[:page], per_page: Refinery::Search.results_per_page)
       end
 


### PR DESCRIPTION
In order to fix search with special characters, we have to convert a seach query to ascii : 
https://github.com/refinery/refinerycms-search/issues/62
https://github.com/dougal/acts_as_indexed#unicode-utf8-support

This PR needs to be merged after, this PR : 
https://github.com/refinery/refinerycms-acts-as-indexed/pull/8
