### PR TITLE
Use new path for refinerycms-acts-as-indexed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ git 'https://github.com/refinery/refinerycms', branch: 'master' do
   end
 end
 
+gem 'refinerycms-acts-as-indexed', git: 'https://github.com/refinery/refinerycms-acts-as-indexed', branch: 'master'
+
 group :test do
   gem 'launchy'
   gem 'pry'

--- a/lib/refinery/search.rb
+++ b/lib/refinery/search.rb
@@ -1,5 +1,5 @@
 require 'refinerycms-core'
-require 'refinerycms-acts-as-indexed'
+require 'refinerycms/acts/as/indexed'
 
 module Refinery
   autoload :SearchGenerator, 'generators/refinery/search/search_generator'

--- a/refinerycms-search.gemspec
+++ b/refinerycms-search.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name              = %q{refinerycms-search}
-  s.version           = %q{4.0.0}
+  s.version           = %q{4.1.0}
   s.summary           = %q{Extra search handling for Refinery CMS}
   s.description       = %q{Provides extra functionality for searching your frontend website using Refinery CMS.}
   s.homepage          = %q{http://refinerycms.com}


### PR DESCRIPTION
Changed to use the new path in `refinerycms-acts-as-indexed`.
Also now dependent on the github master branch of refinerycms-acts-as-indexed